### PR TITLE
JRuby 1.7.4 Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ testdist
 testclasses
 package
 .DS_Store
+.*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM brice/pentaho-kettle:5.0.1
+MAINTAINER Brandon Rice <brice84@gmail.com>
+
+ADD ./ Ruby-Scripting-for-Kettle/
+
+RUN echo "kettle-dir=/data-integration" > /Ruby-Scripting-for-Kettle/build.properties
+RUN cd /Ruby-Scripting-for-Kettle && ant install
+
+WORKDIR /data-integration
+
+EXPOSE 8181
+
+CMD ["./carte.sh", "0.0.0.0", "8181"]
+

--- a/build.xml
+++ b/build.xml
@@ -69,12 +69,12 @@
 		<fileset dir="${kettle-dir}/lib">
 			<include name="**/*.jar" />
 		</fileset>
-		<fileset dir="${kettle-dir}/libext">
+    <!-- <fileset dir="${kettle-dir}/libext">
 			<include name="**/*.jar" />
 		</fileset>
 		<fileset dir="${kettle-dir}/libext/pentaho">
 			<include name="**/*.jar" />
-		</fileset>
+    </fileset> -->
 		<fileset dir="${kettle-dir}/libswt">
 			<include name="**/*.jar" />
 		</fileset>

--- a/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
+++ b/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
@@ -241,9 +241,9 @@ public class RubyStepSyntaxHighlighter {
 				
 				/* read language syntax */
 				int oldOffset = lexerSource.getOffset();
-				keepParsing = lexer.advance();
 				prevt = t;
-				t = lexer.token();
+				t = lexer.nextToken();
+        keepParsing = (t == 0 ? false: true);
 				Object v = lexer.value();
 
 				leftTokenBorder = oldOffset;

--- a/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
+++ b/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
@@ -26,6 +26,8 @@ import org.jruby.parser.ParserSupport;
 import org.jruby.parser.RubyParserResult;
 import org.jruby.parser.Tokens;
 import org.jruby.Ruby;
+import org.jruby.embed.internal.LocalContextProvider;
+import org.jruby.embed.ScriptingContainer;
 import org.pentaho.di.ui.core.widget.StyledTextComp;
 import org.typeexit.kettle.plugin.steps.ruby.RubyStepMeta.RubyVersion;
 
@@ -112,7 +114,8 @@ public class RubyStepSyntaxHighlighter {
 
 		ParserSupport parserSupport = new ParserSupport();
     RubyStepMeta meta = new RubyStepMeta();
-    Ruby runtime = RubyStepFactory.createScriptingContainer(true,meta.getRubyVersion()).getProvider().getRuntime();
+    ScriptingContainer container = RubyStepFactory.createScriptingContainer(true,meta.getRubyVersion());
+    Ruby runtime = container.getProvider().getRuntime();
 		ParserConfiguration parserConfig = new ParserConfiguration(runtime, 0, true, CompatVersion.BOTH);
 		parserSupport.setConfiguration(parserConfig);
 		parserSupport.setResult(new RubyParserResult());

--- a/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
+++ b/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
@@ -26,7 +26,6 @@ import org.jruby.parser.ParserSupport;
 import org.jruby.parser.RubyParserResult;
 import org.jruby.parser.Tokens;
 import org.jruby.Ruby;
-import org.jruby.embed.internal.LocalContextProvider;
 import org.jruby.embed.ScriptingContainer;
 import org.pentaho.di.ui.core.widget.StyledTextComp;
 import org.typeexit.kettle.plugin.steps.ruby.RubyStepMeta.RubyVersion;

--- a/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
+++ b/src/org/typeexit/kettle/plugin/steps/ruby/RubyStepSyntaxHighlighter.java
@@ -243,7 +243,7 @@ public class RubyStepSyntaxHighlighter {
 				int oldOffset = lexerSource.getOffset();
 				prevt = t;
 				t = lexer.nextToken();
-        keepParsing = (t == 0 ? false: true);
+        keepParsing = (t == 0 ? false : true);
 				Object v = lexer.value();
 
 				leftTokenBorder = oldOffset;

--- a/src/org/typeexit/kettle/plugin/steps/ruby/execmodels/SimpleExecutionModel.java
+++ b/src/org/typeexit/kettle/plugin/steps/ruby/execmodels/SimpleExecutionModel.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.jruby.RubyArray;
@@ -62,6 +63,11 @@ public class SimpleExecutionModel implements ExecutionModel {
 			data.forcedHalt = false;
 
 			data.container = RubyStepFactory.createScriptingContainer(true, meta.getRubyVersion());
+
+      List<String> paths = new ArrayList<String>();
+      String newPath = step.environmentSubstitute("${RUBY_LOAD_PATH}");
+      paths.add(newPath);
+      data.container.setLoadPaths(paths); 
 
 			data.runtime = data.container.getProvider().getRuntime();
 


### PR DESCRIPTION
Update to the latest stable JRuby.  Some accompanying syntax changes to go along with the removal of the advance() method from RubyYaccLexer.
